### PR TITLE
Improve `pr` command

### DIFF
--- a/all-distros/bash_aliases
+++ b/all-distros/bash_aliases
@@ -54,8 +54,9 @@ fetchall() {
 }
 
 pr() {
-    git fetch origin "pull/$1/head:pr$1"
-    git switch "pr$1"
+    : ${1?"Usage: pr 12345"}
+    git fetch origin "pull/$1/head:pr/$1" || return 1
+    git switch "pr/$1" || return 1
 }
 
 format() {


### PR DESCRIPTION
- PRs are put in their own folder `pr/`.
- Running `pr` by itself will tell you the correct usage (also happens if you type `pr #12345` because bash doesn't detect it as an argument).
- Returns an error code if the fetch failed instead of continuing to switch branches.