### PR TITLE
Add `pdd` command: `dd` with progress and confirmation step.

### DIFF
--- a/all-distros/bash_aliases
+++ b/all-distros/bash_aliases
@@ -171,3 +171,22 @@ stripogg() {
     done
     echo "Done! "
 }
+
+pdd() {
+        : ${1?"Usage: pdd if=/dev/zero of=/dev/null"}
+        cmd="sudo dd $@ status=progress"
+
+        echo
+        echo "PLEASE REVIEW THE COMMAND AND DEVICE LIST BELOW."
+        echo
+        echo "Command: '$cmd'"
+        echo
+        echo "Devices:"
+        lsblk
+        echo
+        echo -n 'THE DISK OR FILE AFTER "of=" WILL BE PERMANENTLY OVERWRITTEN. Type 'yes' to confirm: ' && read 'x' && [ $x == 'yes' ] || return
+        echo "Running in 5 seconds... Ctrl+C to cancel."
+        sleep 5 || return
+        echo
+        $cmd
+}


### PR DESCRIPTION
Example output:
```
$ pdd if=/dev/zero of=/dev/null

PLEASE REVIEW THE COMMAND AND DEVICE LIST BELOW.

Command: 'sudo dd if=/dev/zero of=/dev/null status=progress'

Devices:
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
nvme0n1     259:0    0   1.8T  0 disk 
├─nvme0n1p1 259:1    0   512M  0 part /boot
└─nvme0n1p2 259:2    0   1.8T  0 part /
nvme1n1     259:3    0 931.5G  0 disk 
├─nvme1n1p1 259:4    0    16M  0 part 
└─nvme1n1p2 259:5    0 931.5G  0 part 

THE DISK OR FILE AFTER "of=" WILL BE PERMANENTLY OVERWRITTEN. Type yes to confirm: yes
Running in 5 seconds... Ctrl+C to cancel.

4858697216 bytes (4.9 GB, 4.5 GiB) copied, 3 s, 1.6 GB/s^C
11213640+0 records in
11213640+0 records out
5741383680 bytes (5.7 GB, 5.3 GiB) copied, 3.54578 s, 1.6 GB/s

```

FYI if you run `pdd somethinghere`, it will suggest command `sudo dd somethinghere status=progress` and print `dd: unrecognized operand ‘somethinghere’` after 5 seconds