### PR TITLE
Add `port` command to find processes listening on a port.

### DIFF
--- a/all-distros/bash_aliases
+++ b/all-distros/bash_aliases
@@ -72,8 +72,8 @@ gk() {
 }
 
 port() {
-  : ${1?"Finds process using port. Usage: port 80"}
-  sudo ss -lptn "sport = :$1" || echo "Port is not in use."
+  : ${1?"Finds processes using port. Example: port 80"}
+  sudo lsof -i :"$1" || echo "Port is not in use."
 }
 
 format() {

--- a/all-distros/bash_aliases
+++ b/all-distros/bash_aliases
@@ -71,6 +71,11 @@ gk() {
     gitkraken "$(pwd)"
 }
 
+port() {
+  : ${1?"Finds process using port. Usage: port 80"}
+  sudo ss -lptn "sport = :$1" || echo "Port is not in use."
+}
+
 format() {
     find . -regex '.*\.\(cpp\|hpp\|cc\|cxx\)' -exec clang-format -style=file -i {} \;
 }


### PR DESCRIPTION
Edit: Source https://stackoverflow.com/a/34659332/7260220, should work on mac and most of linux

```
$ port 80
COMMAND    PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
docker-pr 3920 root    4u  IPv4  42722      0t0  TCP *:http (LISTEN)
docker-pr 3927 root    4u  IPv6  42730      0t0  TCP *:http (LISTEN)
```